### PR TITLE
deps: upgrade @typescript-eslint to support typescript >= 4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mwts",
-  "version": "1.2.3",
+  "version": "1.2.2",
   "description": "MidwayJS TypeScript Style",
   "repository": "midwayjs/mwts",
   "main": "dist/src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mwts",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "MidwayJS TypeScript Style",
   "repository": "midwayjs/mwts",
   "main": "dist/src/index.js",
@@ -37,8 +37,8 @@
   "keywords": [],
   "license": "Apache-2.0",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.2.0",
-    "@typescript-eslint/parser": "^4.2.0",
+    "@typescript-eslint/eslint-plugin": "^5.4.0",
+    "@typescript-eslint/parser": "^5.4.0",
     "chalk": "^4.1.0",
     "eslint": "^7.10.0",
     "eslint-config-prettier": "^8.0.0",
@@ -46,8 +46,8 @@
     "eslint-plugin-prettier": "^3.1.4",
     "execa": "^5.0.0",
     "inquirer": "^7.3.3",
-    "meow": "^9.0.0",
     "json5": "^2.1.3",
+    "meow": "^9.0.0",
     "ncp": "^2.0.0",
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",

--- a/src/init.ts
+++ b/src/init.ts
@@ -176,7 +176,7 @@ async function generateConfigFile(
   let existing;
   try {
     existing = await read(filename, 'utf8');
-  } catch (err) {
+  } catch (err: any) {
     if (err.code === 'ENOENT') {
       /* not found, create it. */
     } else {
@@ -244,9 +244,9 @@ export async function installDefaultTemplate(
 
   try {
     fs.mkdirSync(targetDirName);
-  } catch (error) {
-    if (error.code !== 'EEXIST') {
-      throw error;
+  } catch (err: any) {
+    if (err.code !== 'EEXIST') {
+      throw err;
     }
     // Else, continue and populate files into the existing directory.
   }
@@ -271,7 +271,7 @@ export async function init(options: Options): Promise<boolean> {
   let packageJson;
   try {
     packageJson = (await readJson('./package.json')) as PackageJson;
-  } catch (err) {
+  } catch (err: any) {
     if (err.code !== 'ENOENT') {
       throw new Error(`Unable to open package.json file: ${err.message}`);
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -65,9 +65,9 @@ async function getBase(
     let contents: any;
     try {
       contents = JSON5.parse(json);
-    } catch (e) {
-      e.message = `Unable to parse ${filePath}!\n${e.message}`;
-      throw e;
+    } catch (err: any) {
+      err.message = `Unable to parse ${filePath}!\n${err.message}`;
+      throw err;
     }
 
     if (contents.extends) {
@@ -81,7 +81,7 @@ async function getBase(
     }
 
     return contents;
-  } catch (err) {
+  } catch (err: any) {
     err.message = `Error: ${filePath}\n${err.message}`;
     throw err;
   }
@@ -145,16 +145,17 @@ export async function getTSConfig(
   rootDir: string,
   customReadFilep?: ReadFileP
 ): Promise<ConfigFile> {
-  customReadFilep = customReadFilep || readFilep;
   const readArr = new Set<string>();
-  return getBase('tsconfig.json', customReadFilep, readArr, rootDir);
+  return getBase('tsconfig.json', customReadFilep!, readArr, rootDir);
 }
 
 export function readJSON(filepath: string): unknown {
   const content = fs.readFileSync(filepath, 'utf8');
   try {
     return JSON.parse(content);
-  } catch (e) {
-    throw new Error(`Failed to parse JSON file '${content}' for: ${e.message}`);
+  } catch (err: any) {
+    throw new Error(
+      `Failed to parse JSON file '${content}' for: ${err.message}`
+    );
   }
 }


### PR DESCRIPTION
deps: 升级 `@typescript-eslint ` 的两个包，支持 typescript >= 4.5.0
fix: 一些 typescript 类型错误
